### PR TITLE
Bugfix/vpc lookup issue

### DIFF
--- a/.env
+++ b/.env
@@ -1,9 +1,0 @@
-# AWS configuration
-AWS_ACCOUNT_ID = "XXXXXX" # the AWS account ID
-AWS_REGION = "xx-xxxx-x" # the AWS region
-
-# VPC / VPCE configuration
-VPC_ID="vpc-xxxxxx" # the VPC ID where the VPC endpoints will be created
-AVAILABILITY_ZONES = "xx-xxxx-xx,xx-xxxx-xx" # the availability zones where the VPC endpoints will be created
-PORTS = "xxxx, xxxx, xxxx" # update with your the ports that will be opened in the security group
-VPCE_IPS = "x.x.x.x,x.x.x.x" # the IPs of the VPC endpoints

--- a/.env-example
+++ b/.env-example
@@ -1,0 +1,9 @@
+# AWS configuration
+AWS_ACCOUNT_ID = "XXXXXX" # the AWS account ID
+AWS_REGION = "xx-xxxx-x" # the AWS region
+
+# VPC / VPCE configuration
+VPC_ID="vpc-xxxxxx" # the VPC ID where the VPC endpoints will be created
+AVAILABILITY_ZONES = "xx-xxxx-xx,xx-xxxx-xx" # the availability zones where the VPC endpoints will be created
+PORTS = "xxxx, xxxx, xxxx" # update with your the ports that will be opened in the security group
+VPCE_IPS = "x.x.x.x,x.x.x.x" # the IPs of the VPC endpoints

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.env
+cdk.context.json
+package-lock.json
+cdk.out
+node_modules/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,9 @@ _mongodb._tcp.cluster2-pl-0.XXXX.mongodb.net	service = 0 0 1032 pl-0-us-west-2.X
 
 # Running the script
 ## Step 1
-Update the .env file 
+
+- Copy .env-example to .env
+- Update the .env file with appropriate values
 
 ```
 AWS_ACCOUNT_ID = "XXXXXX" # the AWS account ID

--- a/lib/mongodb_atlas_as_aws_bedrock_knowledge_base-stack.ts
+++ b/lib/mongodb_atlas_as_aws_bedrock_knowledge_base-stack.ts
@@ -21,7 +21,7 @@ export class MongodbAtlasAsAwsBedrockKnowledgeBaseStack extends cdk.Stack {
     const vpcId = process.env.VPC_ID;
     if (!vpcId) { throw new Error('VPC_ID is not defined in the environment variables');}
 
-    const vpc = ec2.Vpc.fromLookup(this, vpcId, { isDefault: false });
+    const vpc = ec2.Vpc.fromLookup(this, 'Vpc', { isDefault: false, vpcId: vpcId });
 
     // Log specific VPC properties
     console.log(`VPC ID: ${vpc.vpcId}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/jest": "^29.5.12",
         "@types/node": "20.11.19",
         "aws-cdk": "2.132.1",
+        "dotenv": "^10.0.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
@@ -2055,6 +2056,15 @@
       "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-to-chromium": {


### PR DESCRIPTION
Fixed Issue #1 

Updated `lib\mongodb_atlas_as_aws_bedrock_knowledge_base-stack.ts` with following change.
```ts
const vpc = ec2.Vpc.fromLookup(this, 'Vpc', { isDefault: false, vpcId: vpcId });`
```

- added .gitignore
- added .env-example
- untracked .env file
- updated README.md